### PR TITLE
Bump FFI dependency to ~> 1.9.0

### DIFF
--- a/webp-ffi.gemspec
+++ b/webp-ffi.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions    << 'ext/webp_ffi/Rakefile'
 
-  spec.add_runtime_dependency "ffi", "~> 1.4.0"
+  spec.add_runtime_dependency "ffi", "~> 1.9.0"
   spec.add_runtime_dependency "ffi-compiler", "~> 0.1.2"
 
   spec.add_development_dependency "bundler", ">= 1.2"


### PR DESCRIPTION
Just bumping a FFI dependency version up to 1.9.0. Doing this because of FFI version requirements conflicts. Specs are passing, I hope they'll all pass on Travis too.
