### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ For Ubuntu, Debian:
 
 For Mac OS:
 
-    brew install libjpg libpng libtiff
+    brew install libjpg libpng libtiff webp
 
 or (for MacPorts):
 
     sudo port install jpeg libpng tiff
 
-Next, you should [install libwebp](https://developers.google.com/speed/webp/docs/compiling). This gem is not support Windows systems (sorry).
+Next, if you did not use `brew` you should [install libwebp](https://developers.google.com/speed/webp/docs/compiling). This gem is not support Windows systems (sorry).
 
 ### Final part
 


### PR DESCRIPTION
Homebrew has `webp` library, but google developers didn't write about this
