### PR TITLE
Add LD_FLAGS and C_FLAGS environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: ruby
 
 before_install:
   - ./spec/travis_build.sh > /dev/null 2>&1
+  - export LD_FLAGS=-L$HOME/opt/lib
+  - export LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib:$HOME/opt/lib
+  - export CPATH=$CPATH:$HOME/opt/include
+
 
 rvm:
   - 1.9.3
@@ -12,7 +16,8 @@ rvm:
   - ruby-head
   - jruby-head
 
-sudo: true
+cache: bundler
+sudo: false
 
 notifications:
   email: false

--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,8 @@ namespace "ffi-compiler" do
       c.cflags << "-arch x86_64"
       c.ldflags << "-arch x86_64"
     end
+    c.ldflags << ENV['LD_FLAGS'] if ENV['LD_FLAGS']
+    c.cflags << ENV['C_FLAGS'] if ENV['C_FLAGS']
   end
 end
 task :compile => ["ffi-compiler:default"]

--- a/ext/webp_ffi/Rakefile
+++ b/ext/webp_ffi/Rakefile
@@ -19,4 +19,6 @@ FFI::Compiler::CompileTask.new('webp_ffi') do |c|
     c.cflags << "-arch x86_64"
     c.ldflags << "-arch x86_64"
   end
+  c.ldflags << ENV['LD_FLAGS'] if ENV['LD_FLAGS']
+  c.cflags << ENV['C_FLAGS'] if ENV['C_FLAGS']
 end

--- a/spec/travis_build.sh
+++ b/spec/travis_build.sh
@@ -2,6 +2,5 @@
 wget http://downloads.webmproject.org/releases/webp/libwebp-0.4.2.tar.gz
 tar xvzf libwebp-0.4.2.tar.gz
 cd libwebp-0.4.2
-./configure
-make && sudo make install
-sudo ln -fs /usr/local/lib/libwebp.* /usr/lib/
+./configure --prefix=$HOME/opt
+make && make install


### PR DESCRIPTION
This makes the travis config compatible with `sudo: false` installation, so this gem can be used in the new [container-based infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/).
